### PR TITLE
js/SLChart.js: Use a relative URL to the CSV in this repository

### DIFF
--- a/js/SLChart.js
+++ b/js/SLChart.js
@@ -13,7 +13,7 @@
  */
 
 // Initial data hardcoded for now
-var dataString = "http://zachtoogood.com/files/SLChart/data/spreadsheet-stronglifts.csv";
+var dataString = "data/spreadsheet-stronglifts.csv";
 parseData(dataString);
 
 


### PR DESCRIPTION
Otherwise when you clone this Chrome and Firefox show you nothing due
to (error from Chrome):

    index.html:1 XMLHttpRequest cannot load
    http://zachtoogood.com/files/SLChart/data/spreadsheet-stronglifts.csv. No
    'Access-Control-Allow-Origin' header is present on the requested
    resource. Origin 'http://example.com is therefore not allowed access.